### PR TITLE
Add a new boolean parameter 'utf8' to VSEval

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -22,14 +22,15 @@ as follows.::
     VSImport(string source, bool "stacked", int "index")
 
     source  - input script path.
-    stacked - if this is set to true, MSB/LSB will be separated and be stacked vertially(default:false).
+    stacked - if this is set to true, MSB/LSB will be separated and be stacked vertically (default: false).
     index   - index of input clip(default:0).
 
 
-    VSEval(string source, bool "stacked", int "index")
+    VSEval(string source, bool "stacked", int "index", bool "utf8")
     
     source - vapoursynth script.
     stacked and index are same as VSImport.
+    utf8   - if this is set to true, source is assumed to be UTF-8 encoded (default: false).
 
 examples:
 ---------


### PR DESCRIPTION
When this option is set (default: false) the source string is assumed to be UTF-8 encoded, instead of the system code page. That way, it's possible to write non-"ANSI" VapourSynth scripts on an AviSynth script.

Obviously it's not intended that users paste encoded text on their avs scripts. This option is useful for AvsPmod, for opening vpy scripts as if they were avs and silently evaluate them with VSEval. And apparently it's also useful for previewing on VirtualDub.
